### PR TITLE
fix: supply sha256 to /github/metadata — its schema requires it

### DIFF
--- a/.github/workflows/plugin-release.yml
+++ b/.github/workflows/plugin-release.yml
@@ -106,23 +106,27 @@ jobs:
       - name: Publish to BOSS Plugin Store
         run: |
           echo "Publishing to BOSS Plugin Store..."
-          # /github buffers the JAR server-side and rejects assets over 50 MB;
-          # /github/metadata streams the hash from the GitHub release instead.
-          # Pick by the built JAR's size — plugins that bundle heavy deps
-          # (editor-tab ships BossEditor + the embedded Kotlin compiler, ~65 MB)
-          # exceed the buffered limit. Max size across jars in case a module
-          # also emits a small classified jar.
-          JAR_SIZE=$(stat -c%s build/libs/*.jar | sort -rn | head -n1)
+          # /github buffers the JAR server-side and rejects assets over 50 MB.
+          # Larger JARs go to /github/metadata, whose contract requires the
+          # publisher to supply the JAR's SHA-256 (the server never downloads
+          # the JAR on that path; clients verify downloads against this hash).
+          # The largest jar in build/libs is the one uploaded to the release,
+          # so hashing it here hashes the exact released bytes.
+          JAR_FILE=$(ls -S build/libs/*.jar | head -n1)
+          JAR_SIZE=$(stat -c%s "$JAR_FILE")
           ENDPOINT="github"
+          BODY="{\"githubUrl\": \"${{ github.server_url }}/${{ github.repository }}\"}"
           if [ "$JAR_SIZE" -gt 52428800 ]; then
             ENDPOINT="github/metadata"
+            SHA256=$(sha256sum "$JAR_FILE" | cut -d' ' -f1)
+            BODY="{\"githubUrl\": \"${{ github.server_url }}/${{ github.repository }}\", \"sha256\": \"$SHA256\"}"
           fi
-          echo "Largest JAR: ${JAR_SIZE} bytes -> POST /${ENDPOINT}"
+          echo "JAR: $JAR_FILE (${JAR_SIZE} bytes) -> POST /${ENDPOINT}"
           RESPONSE=$(curl -s -w "\n%{http_code}" -X POST \
             "https://api.risaboss.com/functions/v1/plugin-store/${ENDPOINT}" \
             -H "Content-Type: application/json" \
             -H "X-API-Key: ${{ secrets.BOSS_STORE_PLUGIN_PUBLISH_KEY }}" \
-            -d "{\"githubUrl\": \"${{ github.server_url }}/${{ github.repository }}\"}")
+            -d "$BODY")
           HTTP_CODE=$(echo "$RESPONSE" | tail -n1)
           BODY=$(echo "$RESPONSE" | head -n-1)
           echo "Response: $BODY"


### PR DESCRIPTION
Follow-up to #7: the `/github/metadata` endpoint's request schema (`PublishFromGitHubMetadataRequestSchema` in BossConsole's plugin-store function) requires a client-supplied `sha256` — the server deliberately never downloads the JAR on that path, so the publisher provides the hash clients verify against. The editor-tab v1.4.3 publish failed with `ZodError: sha256 Required`.

The workflow now hashes the largest jar in `build/libs` (the exact bytes uploaded to the GitHub release) and includes it in the body for the metadata path. The small-jar `/github` path is unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)