### PR TITLE
chore: relicense under Apache-2.0 and point contacts at risalabs.ai

### DIFF
--- a/.github/workflows/plugin-release.yml
+++ b/.github/workflows/plugin-release.yml
@@ -44,8 +44,8 @@ jobs:
           echo "Bumping version: $CURRENT -> $NEW_VERSION"
           sed -i "s/^version = \".*\"/version = \"${NEW_VERSION}\"/" build.gradle.kts
 
-          git config user.name "github-actions[bot]"
-          git config user.email "github-actions[bot]@users.noreply.github.com"
+          git config user.name "Risa Labs"
+          git config user.email "enterprise@risalabs.ai"
           git add build.gradle.kts
           git commit -m "🔖 Bump version to ${NEW_VERSION} [skip ci]"
           git push

--- a/.github/workflows/update-distribution.yml
+++ b/.github/workflows/update-distribution.yml
@@ -114,8 +114,8 @@ jobs:
           cd homebrew-tap
           
           # Configure git
-          git config user.name "kshivang"
-          git config user.email "shivang.iitk@gmail.com"
+          git config user.name "Risa Labs"
+          git config user.email "enterprise@risalabs.ai"
           
           # Update the cask file
           VERSION="${{ steps.release_info.outputs.VERSION }}"
@@ -201,8 +201,8 @@ jobs:
           cd homebrew-cask-repo
           
           # Configure git
-          git config user.name "kshivang"
-          git config user.email "shivang.iitk@gmail.com"
+          git config user.name "Risa Labs"
+          git config user.email "enterprise@risalabs.ai"
           
           # Verify remotes (origin should be our fork, we'll add upstream for official repo)
           echo "🔍 Initial git remotes after cloning from fork:"

--- a/LICENSE
+++ b/LICENSE
@@ -1,57 +1,202 @@
-BOSS - Business OS plus Simulations
-Copyright (c) 2025 Risa Labs Inc. All rights reserved.
 
-PROPRIETARY SOFTWARE LICENSE
+                                 Apache License
+                           Version 2.0, January 2004
+                        http://www.apache.org/licenses/
 
-This software and associated documentation files (the "Software") are proprietary 
-to Risa Labs Inc. ("Licensor"). The Software is protected by copyright laws and 
-international copyright treaties, as well as other intellectual property laws and 
-treaties.
+   TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
 
-PERMITTED USES:
-- You may install and use the Software on devices you own or control
-- You may make backup copies of the Software for archival purposes
-- You may use the Software in accordance with the applicable End User License Agreement
+   1. Definitions.
 
-RESTRICTIONS:
-- You may NOT distribute, sublicense, rent, lease, or sell the Software
-- You may NOT reverse engineer, decompile, or disassemble the Software
-- You may NOT modify, adapt, or create derivative works based on the Software
-- You may NOT remove or alter any proprietary notices or labels on the Software
+      "License" shall mean the terms and conditions for use, reproduction,
+      and distribution as defined by Sections 1 through 9 of this document.
 
-HEALTHCARE DATA COMPLIANCE:
-When processing healthcare or personally identifiable information, you agree to:
-- Comply with applicable healthcare regulations including HIPAA, HITECH, and GDPR
-- Implement appropriate safeguards for protected health information
-- Ensure proper access controls and audit logging
-- Report security incidents as required by applicable law
+      "Licensor" shall mean the copyright owner or entity authorized by
+      the copyright owner that is granting the License.
 
-DISCLAIMER OF WARRANTIES:
-THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, 
-INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A 
-PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL RISA LABS INC. BE LIABLE 
-FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT 
-OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE 
-OR OTHER DEALINGS IN THE SOFTWARE.
+      "Legal Entity" shall mean the union of the acting entity and all
+      other entities that control, are controlled by, or are under common
+      control with that entity. For the purposes of this definition,
+      "control" means (i) the power, direct or indirect, to cause the
+      direction or management of such entity, whether by contract or
+      otherwise, or (ii) ownership of fifty percent (50%) or more of the
+      outstanding shares, or (iii) beneficial ownership of such entity.
 
-LIMITATION OF LIABILITY:
-IN NO EVENT SHALL RISA LABS INC. BE LIABLE FOR ANY SPECIAL, INCIDENTAL, INDIRECT, 
-OR CONSEQUENTIAL DAMAGES WHATSOEVER (INCLUDING, WITHOUT LIMITATION, DAMAGES FOR 
-LOSS OF BUSINESS PROFITS, BUSINESS INTERRUPTION, LOSS OF BUSINESS INFORMATION, OR 
-ANY OTHER PECUNIARY LOSS) ARISING OUT OF THE USE OF OR INABILITY TO USE THE SOFTWARE, 
-EVEN IF RISA LABS INC. HAS BEEN ADVISED OF THE POSSIBILITY OF SUCH DAMAGES.
+      "You" (or "Your") shall mean an individual or Legal Entity
+      exercising permissions granted by this License.
 
-GOVERNING LAW:
-This license shall be governed by and construed in accordance with the laws of the 
-jurisdiction in which Risa Labs Inc. is incorporated, without regard to its conflict 
-of law provisions.
+      "Source" form shall mean the preferred form for making modifications,
+      including but not limited to software source code, documentation
+      source, and configuration files.
 
-CONTACT INFORMATION:
-For licensing inquiries: enterprise@risalabs.ai
-For support: support@risalabs.ai
-For security issues: security@risalabs.ai
+      "Object" form shall mean any form resulting from mechanical
+      transformation or translation of a Source form, including but
+      not limited to compiled object code, generated documentation,
+      and conversions to other media types.
 
-Risa Labs Inc.
-Website: https://www.risalabs.ai
+      "Work" shall mean the work of authorship, whether in Source or
+      Object form, made available under the License, as indicated by a
+      copyright notice that is included in or attached to the work
+      (an example is provided in the Appendix below).
 
-Last Updated: August 3, 2025
+      "Derivative Works" shall mean any work, whether in Source or Object
+      form, that is based on (or derived from) the Work and for which the
+      editorial revisions, annotations, elaborations, or other modifications
+      represent, as a whole, an original work of authorship. For the purposes
+      of this License, Derivative Works shall not include works that remain
+      separable from, or merely link (or bind by name) to the interfaces of,
+      the Work and Derivative Works thereof.
+
+      "Contribution" shall mean any work of authorship, including
+      the original version of the Work and any modifications or additions
+      to that Work or Derivative Works thereof, that is intentionally
+      submitted to Licensor for inclusion in the Work by the copyright owner
+      or by an individual or Legal Entity authorized to submit on behalf of
+      the copyright owner. For the purposes of this definition, "submitted"
+      means any form of electronic, verbal, or written communication sent
+      to the Licensor or its representatives, including but not limited to
+      communication on electronic mailing lists, source code control systems,
+      and issue tracking systems that are managed by, or on behalf of, the
+      Licensor for the purpose of discussing and improving the Work, but
+      excluding communication that is conspicuously marked or otherwise
+      designated in writing by the copyright owner as "Not a Contribution."
+
+      "Contributor" shall mean Licensor and any individual or Legal Entity
+      on behalf of whom a Contribution has been received by Licensor and
+      subsequently incorporated within the Work.
+
+   2. Grant of Copyright License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      copyright license to reproduce, prepare Derivative Works of,
+      publicly display, publicly perform, sublicense, and distribute the
+      Work and such Derivative Works in Source or Object form.
+
+   3. Grant of Patent License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      (except as stated in this section) patent license to make, have made,
+      use, offer to sell, sell, import, and otherwise transfer the Work,
+      where such license applies only to those patent claims licensable
+      by such Contributor that are necessarily infringed by their
+      Contribution(s) alone or by combination of their Contribution(s)
+      with the Work to which such Contribution(s) was submitted. If You
+      institute patent litigation against any entity (including a
+      cross-claim or counterclaim in a lawsuit) alleging that the Work
+      or a Contribution incorporated within the Work constitutes direct
+      or contributory patent infringement, then any patent licenses
+      granted to You under this License for that Work shall terminate
+      as of the date such litigation is filed.
+
+   4. Redistribution. You may reproduce and distribute copies of the
+      Work or Derivative Works thereof in any medium, with or without
+      modifications, and in Source or Object form, provided that You
+      meet the following conditions:
+
+      (a) You must give any other recipients of the Work or
+          Derivative Works a copy of this License; and
+
+      (b) You must cause any modified files to carry prominent notices
+          stating that You changed the files; and
+
+      (c) You must retain, in the Source form of any Derivative Works
+          that You distribute, all copyright, patent, trademark, and
+          attribution notices from the Source form of the Work,
+          excluding those notices that do not pertain to any part of
+          the Derivative Works; and
+
+      (d) If the Work includes a "NOTICE" text file as part of its
+          distribution, then any Derivative Works that You distribute must
+          include a readable copy of the attribution notices contained
+          within such NOTICE file, excluding those notices that do not
+          pertain to any part of the Derivative Works, in at least one
+          of the following places: within a NOTICE text file distributed
+          as part of the Derivative Works; within the Source form or
+          documentation, if provided along with the Derivative Works; or,
+          within a display generated by the Derivative Works, if and
+          wherever such third-party notices normally appear. The contents
+          of the NOTICE file are for informational purposes only and
+          do not modify the License. You may add Your own attribution
+          notices within Derivative Works that You distribute, alongside
+          or as an addendum to the NOTICE text from the Work, provided
+          that such additional attribution notices cannot be construed
+          as modifying the License.
+
+      You may add Your own copyright statement to Your modifications and
+      may provide additional or different license terms and conditions
+      for use, reproduction, or distribution of Your modifications, or
+      for any such Derivative Works as a whole, provided Your use,
+      reproduction, and distribution of the Work otherwise complies with
+      the conditions stated in this License.
+
+   5. Submission of Contributions. Unless You explicitly state otherwise,
+      any Contribution intentionally submitted for inclusion in the Work
+      by You to the Licensor shall be under the terms and conditions of
+      this License, without any additional terms or conditions.
+      Notwithstanding the above, nothing herein shall supersede or modify
+      the terms of any separate license agreement you may have executed
+      with Licensor regarding such Contributions.
+
+   6. Trademarks. This License does not grant permission to use the trade
+      names, trademarks, service marks, or product names of the Licensor,
+      except as required for reasonable and customary use in describing the
+      origin of the Work and reproducing the content of the NOTICE file.
+
+   7. Disclaimer of Warranty. Unless required by applicable law or
+      agreed to in writing, Licensor provides the Work (and each
+      Contributor provides its Contributions) on an "AS IS" BASIS,
+      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+      implied, including, without limitation, any warranties or conditions
+      of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+      PARTICULAR PURPOSE. You are solely responsible for determining the
+      appropriateness of using or redistributing the Work and assume any
+      risks associated with Your exercise of permissions under this License.
+
+   8. Limitation of Liability. In no event and under no legal theory,
+      whether in tort (including negligence), contract, or otherwise,
+      unless required by applicable law (such as deliberate and grossly
+      negligent acts) or agreed to in writing, shall any Contributor be
+      liable to You for damages, including any direct, indirect, special,
+      incidental, or consequential damages of any character arising as a
+      result of this License or out of the use or inability to use the
+      Work (including but not limited to damages for loss of goodwill,
+      work stoppage, computer failure or malfunction, or any and all
+      other commercial damages or losses), even if such Contributor
+      has been advised of the possibility of such damages.
+
+   9. Accepting Warranty or Additional Liability. While redistributing
+      the Work or Derivative Works thereof, You may choose to offer,
+      and charge a fee for, acceptance of support, warranty, indemnity,
+      or other liability obligations and/or rights consistent with this
+      License. However, in accepting such obligations, You may act only
+      on Your own behalf and on Your sole responsibility, not on behalf
+      of any other Contributor, and only if You agree to indemnify,
+      defend, and hold each Contributor harmless for any liability
+      incurred by, or claims asserted against, such Contributor by reason
+      of your accepting any such warranty or additional liability.
+
+   END OF TERMS AND CONDITIONS
+
+   APPENDIX: How to apply the Apache License to your work.
+
+      To apply the Apache License to your work, attach the following
+      boilerplate notice, with the fields enclosed by brackets "[]"
+      replaced with your own identifying information. (Don't include
+      the brackets!)  The text should be enclosed in the appropriate
+      comment syntax for the file format. We also recommend that a
+      file or class name and description of purpose be included on the
+      same "printed page" as the copyright notice for easier
+      identification within third-party archives.
+
+   Copyright [yyyy] [name of copyright owner]
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.

--- a/NOTICE
+++ b/NOTICE
@@ -1,0 +1,136 @@
+BOSS — Business OS + Simulator
+Copyright 2025-2026 Risa Labs Inc.
+
+The BOSS source code is licensed under the Apache License, Version 2.0. A copy
+of that license is in the LICENSE file alongside this notice, and the source is
+published at https://github.com/risa-labs-inc/BossConsole.
+
+IMPORTANT: the installers distributed from this repository are not pure
+Apache-2.0 artifacts. They embed a Java runtime, a commercial browser library,
+and third-party open-source components, each of which remains under its own
+license. The Apache-2.0 grant in LICENSE covers Risa Labs' own code — it does
+not extend to the components listed below, and nothing in this notice grants
+rights beyond what those upstream licenses allow.
+
+
+===============================================================================
+1. Not open source — redistribution is restricted
+===============================================================================
+
+JxBrowser 9.3.0
+  Copyright TeamDev Ltd. Commercial license; NOT open source.
+  BOSS bundles the JxBrowser Java library and calls it under a commercial
+  license held by Risa Labs Inc. That license covers this distribution of
+  BOSS. It does NOT grant you the right to extract, reuse, or redistribute
+  JxBrowser outside BOSS, and it does not transfer to you as a recipient.
+  Using JxBrowser in your own product requires your own license from TeamDev.
+  https://www.teamdev.com/jxbrowser-licensing
+
+
+===============================================================================
+2. Copyleft and dual-licensed components
+===============================================================================
+
+Eclipse Temurin JRE 17 (Adoptium)
+  GNU General Public License, version 2, WITH the Classpath Exception.
+  The installers are built with jpackage and embed a Java runtime image. The
+  Classpath Exception is what permits BOSS's own code to remain under
+  Apache-2.0 while linking against this runtime; it does not relax the GPL
+  terms of the runtime itself.
+  https://adoptium.net/temurin/  |  https://openjdk.org/legal/gplv2+ce.html
+
+BossEditor (com.risaboss:bosseditor-compose-desktop)
+  GNU Lesser General Public License, version 3.0.
+  Copyright Risa Labs Inc. Bundled and linked as a library. LGPL-3.0 entitles
+  you to the library's source and to relink BOSS against a modified version.
+  Complete source: https://github.com/risa-labs-inc/BossEditor
+
+BossTerm (com.risaboss:bossterm-compose)
+  Dual-licensed: LGPLv3 OR Apache-2.0. Used here under Apache-2.0.
+  Copyright the BossTerm authors. Bundled inside the terminal-tab plugin.
+  Because upstream offers Apache-2.0 as an alternative, no LGPL relinking
+  obligation attaches to this distribution. You may take it under either
+  license.
+  Complete source: https://github.com/kshivang/BossTerm
+
+Java Native Access (JNA) 5.19.1
+  Dual-licensed: LGPL-2.1-or-later OR Apache-2.0. Used here under Apache-2.0.
+  https://github.com/java-native-access/jna
+
+Logback 1.5.38
+  Dual-licensed: Eclipse Public License 1.0 OR LGPL-2.1. Used here under
+  EPL-1.0. Copyright QOS.ch.
+  https://logback.qos.ch/license.html
+
+
+===============================================================================
+3. Downloaded after installation
+===============================================================================
+
+Chromium (distributed as "boss-chromium")
+  BSD-3-Clause, plus the additional licenses enumerated in Chromium's own
+  credits. Copyright The Chromium Authors and others.
+  Chromium binaries are deliberately NOT bundled in the installers; BOSS
+  fetches a branded engine build on first launch into ~/.boss/boss-chromium.
+  The engine is therefore not covered by this repository's LICENSE, and its
+  own terms govern it. Full per-component credits are viewable from the
+  running engine at chrome://credits.
+  https://www.chromium.org/  |  https://chromium.googlesource.com/chromium/src/+/main/LICENSE
+
+
+===============================================================================
+4. Permissive components
+===============================================================================
+
+MIT License
+  SLF4J 2.0.18 — Copyright QOS.ch Sarl
+  supabase-kt 3.6.0 — Copyright the supabase-kt contributors
+  PreCompose 1.6.2 — Copyright Tlaster
+  compose-icons 1.1.1 — Copyright devsrsouza and contributors. The wrapper
+    library is MIT; each bundled icon set carries its own upstream terms,
+    including Font Awesome Free (CC BY 4.0 icons, SIL OFL 1.1 fonts, MIT
+    code), Simple Icons (CC0-1.0), and Feather (MIT).
+
+BSD 3-Clause License
+  Protocol Buffers 4.35.1 — Copyright Google LLC
+
+Apache License 2.0
+  Kotlin 2.4.0 and the kotlinx libraries (coroutines, serialization,
+    datetime) — Copyright JetBrains s.r.o. and contributors
+  Compose Multiplatform 1.11.1 — Copyright JetBrains s.r.o.
+  Jetpack Compose and AndroidX Lifecycle — Copyright The Android Open
+    Source Project
+  Ktor 3.4.3 — Copyright JetBrains s.r.o.
+  gRPC 1.82.2 and grpc-kotlin 1.5.0 — Copyright The gRPC Authors
+  Netty 4.2.15.Final — Copyright The Netty Project
+  ZXing 3.5.4 — Copyright ZXing Authors
+  Decompose 3.5.0, Essenty 2.5.0 — Copyright Arkadii Ivanov
+  Clikt 5.1.0 — Copyright AJ Alt
+  IntelliJ Platform PSI 243.21565.199 — Copyright JetBrains s.r.o.
+
+  These carry no notice obligation beyond attribution and the retention of
+  their license text, which travels with each artifact inside the
+  distribution.
+
+
+===============================================================================
+5. First-party plugins bundled with the installers
+===============================================================================
+
+The installers ship the following BOSS plugins, all Copyright Risa Labs Inc.:
+
+  boss-plugin-api, terminal-tab, terminal, fluck-browser, editor-tab,
+  plugin-manager, bookmarks
+
+These plugin repositories do not currently publish their own license files.
+Until they do, treat them as proprietary to Risa Labs Inc. and not covered by
+the Apache-2.0 grant in LICENSE. Note that terminal-tab embeds BossTerm and
+editor-tab builds against BossEditor; see section 2 for those components.
+
+
+===============================================================================
+
+This notice describes the composition of the BOSS distributions as of BOSS
+9.x. Component versions change between releases; the authoritative dependency
+set for any given release is the version catalog in that release's source tree
+(gradle/libs.versions.toml). Corrections are welcome via issue or pull request.

--- a/NOTICE
+++ b/NOTICE
@@ -41,9 +41,15 @@ Eclipse Temurin JRE 17 (Adoptium)
 
 BossEditor (com.risaboss:bosseditor-compose-desktop)
   GNU Lesser General Public License, version 3.0.
-  Copyright Risa Labs Inc. Bundled and linked as a library. LGPL-3.0 entitles
-  you to the library's source and to relink BOSS against a modified version.
+  Copyright Risa Labs Inc. Bundled inside the editor-tab plugin's JAR, not
+  provided by the host classloader. LGPL-3.0 entitles you to the library's
+  source and to relink against a modified version.
   Complete source: https://github.com/risa-labs-inc/BossEditor
+
+  BossEditor is being relicensed to Apache-2.0. That change is not
+  retroactive: the versions bundled today (1.0.4 in editor-tab) were
+  published under LGPL-3.0 and remain so. This entry moves to section 4 once
+  a post-relicense release ships and the plugin's pin is bumped.
 
 BossTerm (com.risaboss:bossterm-compose)
   Dual-licensed: LGPLv3 OR Apache-2.0. Used here under Apache-2.0.
@@ -117,15 +123,19 @@ Apache License 2.0
 5. First-party plugins bundled with the installers
 ===============================================================================
 
-The installers ship the following BOSS plugins, all Copyright Risa Labs Inc.:
+The installers ship the following BOSS plugins, all Copyright Risa Labs Inc.
+and all licensed under the Apache License, Version 2.0:
 
   boss-plugin-api, terminal-tab, terminal, fluck-browser, editor-tab,
   plugin-manager, bookmarks
 
-These plugin repositories do not currently publish their own license files.
-Until they do, treat them as proprietary to Risa Labs Inc. and not covered by
-the Apache-2.0 grant in LICENSE. Note that terminal-tab embeds BossTerm and
-editor-tab builds against BossEditor; see section 2 for those components.
+Two of them bundle a third-party library inside their own JAR and carry their
+own NOTICE recording it:
+
+  terminal-tab  bundles BossTerm, taken under its Apache-2.0 option
+  editor-tab    bundles BossEditor under LGPL-3.0
+
+See section 2 for both libraries.
 
 
 ===============================================================================

--- a/README.md
+++ b/README.md
@@ -298,6 +298,6 @@ BOSS is developed by [Risa Labs](https://www.risalabs.ai), a company focused on 
 
 ---
 
-**© 2025-2026 Risa Labs Inc.** Licensed under the [Apache License, Version 2.0](LICENSE).
+**© 2025-2026 Risa Labs Inc.** Licensed under the [Apache License, Version 2.0](LICENSE). The installers bundle third-party components under their own terms — including a commercial browser library and a GPL+CE Java runtime. See [NOTICE](NOTICE).
 
 For enterprise licensing and custom deployments, contact [enterprise@risalabs.ai](mailto:enterprise@risalabs.ai)

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 [![BOSS Version](https://img.shields.io/github/v/release/risa-labs-inc/BossConsole-Releases.svg?label=BOSS&color=brightgreen)](https://github.com/risa-labs-inc/BossConsole-Releases/releases/latest)
 [![Platform](https://img.shields.io/badge/platform-macOS%20%7C%20Windows%20%7C%20Linux-blue.svg)](https://github.com/risa-labs-inc/BossConsole-Releases/releases/latest)
-[![License](https://img.shields.io/badge/license-Proprietary-red.svg)](https://github.com/risa-labs-inc/BossConsole-Releases/blob/main/LICENSE)
+[![License](https://img.shields.io/badge/license-Apache_2.0-blue.svg)](https://github.com/risa-labs-inc/BossConsole-Releases/blob/main/LICENSE)
 [![Downloads](https://img.shields.io/github/downloads/risa-labs-inc/BossConsole-Releases/total.svg)](https://github.com/risa-labs-inc/BossConsole-Releases/releases)
 
 BOSS (Business OS + Simulator) is a sophisticated, AI-powered workspace designed for complex business operations, with specialized features for healthcare administration, workflow automation, and intelligent process management.
@@ -298,6 +298,6 @@ BOSS is developed by [Risa Labs](https://www.risalabs.ai), a company focused on 
 
 ---
 
-**© 2025 Risa Labs Inc. All rights reserved.**
+**© 2025-2026 Risa Labs Inc.** Licensed under the [Apache License, Version 2.0](LICENSE).
 
 For enterprise licensing and custom deployments, contact [enterprise@risalabs.ai](mailto:enterprise@risalabs.ai)

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -213,4 +213,4 @@ We acknowledge and appreciate security researchers who help improve BOSS securit
 
 For additional security questions or concerns, please contact our security team at [security@risalabs.ai](mailto:security@risalabs.ai).
 
-**© 2025 Risa Labs Inc. All rights reserved.**
+**© 2025-2026 Risa Labs Inc.**

--- a/scripts/setup-apt-repo.sh
+++ b/scripts/setup-apt-repo.sh
@@ -67,12 +67,12 @@ done
 echo "✅ Created Release file"
 
 # Sign Release file if GPG key is available
-if command -v gpg &> /dev/null && gpg --list-secret-keys | grep -q "noreply@risa-labs.com"; then
-    gpg --default-key "noreply@risa-labs.com" -abs -o dists/stable/Release.gpg dists/stable/Release
-    gpg --default-key "noreply@risa-labs.com" --clearsign -o dists/stable/InRelease dists/stable/Release
+if command -v gpg &> /dev/null && gpg --list-secret-keys | grep -q "enterprise@risalabs.ai"; then
+    gpg --default-key "enterprise@risalabs.ai" -abs -o dists/stable/Release.gpg dists/stable/Release
+    gpg --default-key "enterprise@risalabs.ai" --clearsign -o dists/stable/InRelease dists/stable/Release
     echo "✅ Signed Release file"
 else
-    echo "⚠️  No GPG key found for noreply@risa-labs.com"
+    echo "⚠️  No GPG key found for enterprise@risalabs.ai"
     echo "   Repository will work but packages won't be signed"
 fi
 


### PR DESCRIPTION
## Why

BossConsole is now public under Apache-2.0, but this distribution repo still shipped a proprietary "all rights reserved" `LICENSE` and a red **Proprietary** badge. Two repos describing the same product stated contradictory terms.

## What changed

| Area | Before | After |
|---|---|---|
| `LICENSE` | Proprietary, all rights reserved | Apache-2.0, byte-identical to BossConsole's |
| `NOTICE` | *(absent)* | Third-party terms for everything in the installers |
| `README.md` badge | `license-Proprietary-red` | `license-Apache_2.0-blue` |
| `README.md` / `SECURITY.md` footer | `© 2025 … All rights reserved.` | `© 2025-2026 Risa Labs Inc.` + license and NOTICE links |
| `scripts/setup-apt-repo.sh` | `noreply@risa-labs.com` | `enterprise@risalabs.ai` |
| `update-distribution.yml` | `kshivang <shivang.iitk@gmail.com>` | `Risa Labs <enterprise@risalabs.ai>` |
| `plugin-release.yml` | `github-actions[bot]` | `Risa Labs <enterprise@risalabs.ai>` |

## The NOTICE

A bare Apache-2.0 `LICENSE` at the root of a repo that ships **installers** can read as covering the whole download. It doesn't: the installers embed a commercially-licensed browser library and a GPL+CE Java runtime, and link an LGPL-3.0 library. `NOTICE` now states that explicitly, organised by obligation:

1. **Not open source** — JxBrowser 9.3.0 (TeamDev, commercial). Spells out that our license covers *this* distribution and does not transfer to recipients.
2. **Copyleft / dual-licensed** — Temurin JRE 17 (GPL-2.0 WITH Classpath-Exception), BossEditor (LGPL-3.0), BossTerm (LGPLv3 **or** Apache-2.0), JNA (LGPL-2.1 or Apache-2.0), Logback (EPL-1.0 or LGPL-2.1).
3. **Downloaded after installation** — Chromium, with a note that it is deliberately absent from the installers.
4. **Permissive** — the MIT / BSD-3 / Apache-2.0 set, with versions and copyright holders.
5. **First-party bundled plugins** — see the gap flagged below.

### Licenses were read, not recalled

Every entry came from the `<licenses>` block of the resolved POM in the Gradle cache, not from memory. That corrected two things I had wrong:

- **BossTerm is dual-licensed** LGPLv3 **or** Apache-2.0 (`README.md:718-722`), not LGPL-only. Taken under Apache-2.0, no relinking obligation attaches. **BossEditor is LGPL-3.0 only**, so that obligation is real and the NOTICE points at the source.
- **Chromium is not in the installers.** `composeApp/build.gradle.kts:760-761` excludes the platform binary and fetches a branded engine on first launch (`~/.boss/boss-chromium`), so it belongs in its own section rather than the bundled list.

Two entries could not be verified from local artifacts and rest on upstream project licensing: **IntelliJ Platform PSI** (the `com.jetbrains.intellij.platform` POMs declare no `<licenses>` block and weren't in the local cache) and the **compose-icons icon sets** (the wrapper POM is MIT; per-set terms come from the upstream projects). Worth a look if counsel reviews this.

## Verification

- `LICENSE` is byte-identical to `BossConsole/LICENSE` and `BossConsoleRust/LICENSE` — all three `shasum` to `2b8b815229aa8a61e483fb4ba0588b8b6c491890`.
- All 5 workflow YAML files parse; `setup-apt-repo.sh` passes `bash -n`.
- **`sync-release.yml` will not clobber this.** BossConsole's sync step only `sed`s version/date strings inside `| **v…` and `### **v…` patterns before `git add README.md`. The badge (line 5) and footer fall outside those patterns, so release automation preserves them.

## ⚠️ Two things still outstanding

**1. The seven bundled plugins publish no license file.** `boss-plugin-api`, `terminal-tab`, `terminal`, `fluck-browser`, `editor-tab`, `plugin-manager`, and `bookmarks` all ship inside the installers, and none of their repos contains a `LICENSE`. The NOTICE says to treat them as proprietary rather than inventing a license for them — but that is a placeholder, not an answer. If they are meant to be Apache-2.0 like the host, each repo needs a `LICENSE` added.

**2. The apt repo will publish unsigned.** `setup-apt-repo.sh` selects a GPG key by matching the maintainer email. No key exists for `enterprise@risalabs.ai`, so the script now takes its `⚠️ No GPG key found` branch. Packages still install, but unsigned until a key with that identity is created.

## Housekeeping

`BossConsole/boss-releases/` is a gitignored local clone of this repo, last updated 3 Jan 2026, still holding the old proprietary `LICENSE`. Pushing from it would revert this change — worth deleting.

Companions: risa-labs-inc/BossConsole#117, risa-labs-inc/BossConsoleLite#28, kshivang/BossTerm#356, risa-labs-inc/BossEditor#11
