### PR TITLE
Point downloads at the always-latest release links

### DIFF
--- a/.github/workflows/test-install.yml
+++ b/.github/workflows/test-install.yml
@@ -64,6 +64,15 @@ jobs:
           echo "$OUTPUT"
           echo "$OUTPUT" | grep -q "darwin"
 
+      # Every other dry-run pins --version, which skips version resolution
+      # entirely — so without this step the lookup path ships untested.
+      - name: Test latest-version resolution (dry-run, unpinned)
+        run: |
+          OUTPUT=$(./install.sh --dry-run 2>&1)
+          echo "$OUTPUT"
+          echo "$OUTPUT" | grep -qE 'Installing BOSS version [0-9]+\.[0-9]+\.[0-9]+'
+          echo "$OUTPUT" | grep -q 'app-releases/boss/'
+
       - name: Test install (real)
         if: github.event_name == 'release' || github.event.inputs.run_real_install == 'true'
         run: ./install.sh
@@ -95,6 +104,15 @@ jobs:
           echo "$OUTPUT"
           echo "$OUTPUT" | grep -q "linux"
           echo "$OUTPUT" | grep -q "amd64"
+
+      # Every other dry-run pins --version, which skips version resolution
+      # entirely — so without this step the lookup path ships untested.
+      - name: Test latest-version resolution (dry-run, unpinned)
+        run: |
+          OUTPUT=$(./install.sh --dry-run 2>&1)
+          echo "$OUTPUT"
+          echo "$OUTPUT" | grep -qE 'Installing BOSS version [0-9]+\.[0-9]+\.[0-9]+'
+          echo "$OUTPUT" | grep -q 'app-releases/boss/'
 
       - name: Test install (real)
         if: github.event_name == 'release' || github.event.inputs.run_real_install == 'true'
@@ -234,6 +252,20 @@ jobs:
           .\install.ps1 -DryRun -Version 8.15.10
         shell: pwsh
 
+      # -Version 8.15.10 above skips Get-LatestVersion entirely, so without
+      # this step the lookup path ships untested on Windows.
+      - name: Test latest-version resolution (dry-run, unpinned)
+        run: |
+          $out = (.\install.ps1 -DryRun 2>&1 | Out-String)
+          Write-Host $out
+          if ($out -notmatch 'Installing BOSS version \d+\.\d+\.\d+') {
+            throw "version was not resolved"
+          }
+          if ($out -notmatch 'app-releases/boss/') {
+            throw "did not download from the release CDN"
+          }
+        shell: pwsh
+
       - name: Test install (real)
         if: github.event_name == 'release' || github.event.inputs.run_real_install == 'true'
         run: .\install.ps1
@@ -275,6 +307,16 @@ jobs:
       - name: Test /dryrun
         run: |
           install.bat /dryrun /version:8.15.10
+        shell: cmd
+
+      # /version above skips :get_latest_version entirely, so without this step
+      # the PowerShell-backed lookup in install.bat ships untested.
+      - name: Test latest-version resolution (dryrun, unpinned)
+        run: |
+          install.bat /dryrun > out.txt 2>&1
+          type out.txt
+          findstr /r /c:"Installing BOSS version [0-9][0-9]*\.[0-9][0-9]*\.[0-9]" out.txt || exit /b 1
+          findstr /c:"app-releases/boss/" out.txt || exit /b 1
         shell: cmd
 
       - name: Test install (real)

--- a/.github/workflows/test-install.yml
+++ b/.github/workflows/test-install.yml
@@ -256,7 +256,10 @@ jobs:
       # this step the lookup path ships untested on Windows.
       - name: Test latest-version resolution (dry-run, unpinned)
         run: |
-          $out = (.\install.ps1 -DryRun 2>&1 | Out-String)
+          # *>&1, not 2>&1: the script reports progress with Write-Host, which
+          # writes to the information stream (6). Merging only stderr leaves
+          # $out empty even though the console shows every line.
+          $out = (.\install.ps1 -DryRun *>&1 | Out-String)
           Write-Host $out
           if ($out -notmatch 'Installing BOSS version \d+\.\d+\.\d+') {
             throw "version was not resolved"

--- a/.github/workflows/update-distribution.yml
+++ b/.github/workflows/update-distribution.yml
@@ -73,7 +73,14 @@ jobs:
           echo "RELEASE_URL=$RELEASE_URL" >> $GITHUB_OUTPUT
           echo "TRIGGER_TYPE=$TRIGGER_TYPE" >> $GITHUB_OUTPUT
           echo "ASSET_NAME=BOSS-${VERSION}-Universal.dmg" >> $GITHUB_OUTPUT
+          # Deliberately a pinned, versioned URL rather than a `latest-release`
+          # link: a Homebrew cask pairs its url with a sha256, so it cannot
+          # point at a moving target. GitHub is the primary source here for a
+          # reason too — this job runs on `release: published`, which fires
+          # before sync-release finishes uploading the assets to the bucket, so
+          # the CDN copy may not exist yet. It is the fallback, not the default.
           echo "DOWNLOAD_URL=https://github.com/risa-labs-inc/BossConsole-Releases/releases/download/v${VERSION}/BOSS-${VERSION}-Universal.dmg" >> $GITHUB_OUTPUT
+          echo "FALLBACK_DOWNLOAD_URL=https://api.risaboss.com/storage/v1/object/public/app-releases/boss/${VERSION}/BOSS-${VERSION}-Universal.dmg" >> $GITHUB_OUTPUT
           echo "PR_MESSAGE=${{ github.event.inputs.pr_message || '' }}" >> $GITHUB_OUTPUT
           echo "📦 Processing BOSS release $VERSION"
 
@@ -91,18 +98,26 @@ jobs:
       - name: Calculate SHA256 hash for Homebrew
         id: calculate_hash
         run: |
-          # Download the DMG file to calculate SHA256
+          set -euo pipefail
+
+          DMG="BOSS-${{ steps.release_info.outputs.VERSION }}-Universal.dmg"
+
+          # Download the DMG file to calculate SHA256. Both sources hold the
+          # same bytes — sync-release uploads the GitHub assets to the bucket
+          # verbatim — so either yields the hash Homebrew users will see.
           echo "⬇️ Downloading DMG to calculate SHA256..."
-          curl -fsSL -o "BOSS-${{ steps.release_info.outputs.VERSION }}-Universal.dmg" \
-            "${{ steps.release_info.outputs.DOWNLOAD_URL }}"
-          
+          if ! curl -fsSL -o "$DMG" "${{ steps.release_info.outputs.DOWNLOAD_URL }}"; then
+            echo "::warning::GitHub asset unavailable; falling back to the release CDN"
+            curl -fsSL -o "$DMG" "${{ steps.release_info.outputs.FALLBACK_DOWNLOAD_URL }}"
+          fi
+
           # Calculate SHA256
-          SHA256=$(sha256sum "BOSS-${{ steps.release_info.outputs.VERSION }}-Universal.dmg" | cut -d' ' -f1)
+          SHA256=$(sha256sum "$DMG" | cut -d' ' -f1)
           echo "SHA256=$SHA256" >> $GITHUB_OUTPUT
           echo "🔒 Calculated SHA256: $SHA256"
           
           # Clean up downloaded file
-          rm -f "BOSS-${{ steps.release_info.outputs.VERSION }}-Universal.dmg"
+          rm -f "$DMG"
 
       - name: Update Homebrew Tap
         id: update_tap

--- a/README.md
+++ b/README.md
@@ -88,7 +88,7 @@ BOSS includes optimized layouts for different roles:
 ## 💻 System Requirements
 
 ### macOS
-- **OS**: macOS 11.0 (Big Sur) or later
+- **OS**: macOS 13.0 (Ventura) or later
 - **Architecture**: Universal (Apple Silicon native, Intel via Rosetta 2)
 - **Memory**: 4 GB RAM minimum, 8 GB recommended
 - **Storage**: 500 MB available space

--- a/README.md
+++ b/README.md
@@ -9,12 +9,17 @@ BOSS (Business OS + Simulator) is a sophisticated, AI-powered workspace designed
 
 ## 🚀 Latest Release
 
+Every link below downloads the newest release directly — no version to look up, nothing to keep current.
+
 | Platform | Architecture | Download |
 |----------|--------------|----------|
-| **macOS** | Universal (Apple Silicon + Intel) | [🍺 Homebrew](https://formulae.brew.sh/cask/boss) \| [📦 DMG](https://github.com/risa-labs-inc/BossConsole-Releases/releases/latest) |
-| **Windows** | x64 | [📦 MSI](https://github.com/risa-labs-inc/BossConsole-Releases/releases/latest) |
-| **Windows** | ARM64 | [📦 MSI](https://github.com/risa-labs-inc/BossConsole-Releases/releases/latest) |
-| **Linux** | AMD64 / ARM64 | [📦 DEB](https://github.com/risa-labs-inc/BossConsole-Releases/releases/latest) \| [📦 RPM](https://github.com/risa-labs-inc/BossConsole-Releases/releases/latest) \| [📦 JAR](https://github.com/risa-labs-inc/BossConsole-Releases/releases/latest) |
+| **macOS** | Universal (Apple Silicon + Intel) | [🍺 Homebrew](https://formulae.brew.sh/cask/boss) \| [📦 DMG](https://api.risaboss.com/functions/v1/latest-release?app=boss&download=dmg) |
+| **Windows** | x64 | [📦 MSI](https://api.risaboss.com/functions/v1/latest-release?app=boss&download=msi) |
+| **Windows** | ARM64 | [📦 MSI](https://api.risaboss.com/functions/v1/latest-release?app=boss&download=msi&arch=arm64) |
+| **Linux** | AMD64 | [📦 DEB](https://api.risaboss.com/functions/v1/latest-release?app=boss&download=deb&arch=amd64) \| [📦 RPM](https://api.risaboss.com/functions/v1/latest-release?app=boss&download=rpm&arch=amd64) \| [📦 JAR](https://api.risaboss.com/functions/v1/latest-release?app=boss&download=jar&arch=amd64) |
+| **Linux** | ARM64 | [📦 DEB](https://api.risaboss.com/functions/v1/latest-release?app=boss&download=deb&arch=arm64) \| [📦 RPM](https://api.risaboss.com/functions/v1/latest-release?app=boss&download=rpm&arch=arm64) \| [📦 JAR](https://api.risaboss.com/functions/v1/latest-release?app=boss&download=jar&arch=arm64) |
+
+These redirect to the current installer and need no API key. Release metadata — version, every asset, sha256 checksums — is at [`?app=boss`](https://api.risaboss.com/functions/v1/latest-release?app=boss). Pre-releases are excluded by default; add `&prerelease=true` to any link to consider them too, and `&channel=beta` (or `alpha`, `rc`) to track a single channel. To browse or pin a specific version, see [all releases](https://github.com/risa-labs-inc/BossConsole-Releases/releases).
 
 > 💡 **Quick Install (Recommended)**:
 > ```bash
@@ -170,7 +175,7 @@ brew update && brew upgrade --cask boss
 <details>
 <summary><strong>macOS: Direct Download (DMG)</strong></summary>
 
-1. Download the latest DMG file from [Releases](https://github.com/risa-labs-inc/BossConsole-Releases/releases/latest)
+1. Download [BOSS for macOS](https://api.risaboss.com/functions/v1/latest-release?app=boss&download=dmg) — one Universal DMG covers Apple Silicon and Intel
 2. Mount the DMG and drag BOSS to Applications
 3. Launch BOSS from Applications folder
 </details>
@@ -178,7 +183,7 @@ brew update && brew upgrade --cask boss
 <details>
 <summary><strong>Windows: Direct Download (MSI)</strong></summary>
 
-1. Download the latest MSI installer from [Releases](https://github.com/risa-labs-inc/BossConsole-Releases/releases/latest)
+1. Download the installer for your architecture — [x64](https://api.risaboss.com/functions/v1/latest-release?app=boss&download=msi) or [ARM64](https://api.risaboss.com/functions/v1/latest-release?app=boss&download=msi&arch=arm64)
 2. Run the installer with administrator privileges
 3. Launch BOSS from Start Menu or Desktop shortcut
 </details>
@@ -186,16 +191,17 @@ brew update && brew upgrade --cask boss
 <details>
 <summary><strong>Linux: Manual Package Installation</strong></summary>
 
-> **📝 Note**: BOSS packages are large (~250MB) and exceed GitHub's file size limits for APT repositories. We provide direct downloads from GitHub Releases instead.
+> **📝 Note**: BOSS packages are large (~250MB) and exceed GitHub's file size limits for APT repositories. We provide direct downloads instead.
+
+Swap `arch=amd64` for `arch=arm64` on an aarch64 machine. Quote the URL — the shell would otherwise read `&` as "run in background".
 
 **Ubuntu/Debian (DEB Package)**
 ```bash
 # Download latest DEB package
-wget $(curl -s https://api.github.com/repos/risa-labs-inc/BossConsole-Releases/releases/latest | grep "browser_download_url.*\.deb" | cut -d '"' -f 4)
+curl -fL -o boss-latest.deb "https://api.risaboss.com/functions/v1/latest-release?app=boss&download=deb&arch=amd64"
 
-# Install
-sudo dpkg -i BOSS-*.deb
-sudo apt-get install -f  # Fix any missing dependencies
+# Install — apt resolves dependencies and honours Recommends (dpkg -i skips those)
+sudo apt-get install ./boss-latest.deb
 
 # Launch
 boss
@@ -204,11 +210,11 @@ boss
 **RHEL/Fedora/openSUSE (RPM Package)**
 ```bash
 # Download latest RPM package
-wget $(curl -s https://api.github.com/repos/risa-labs-inc/BossConsole-Releases/releases/latest | grep "browser_download_url.*\.rpm" | cut -d '"' -f 4)
+curl -fL -o boss-latest.rpm "https://api.risaboss.com/functions/v1/latest-release?app=boss&download=rpm&arch=amd64"
 
 # Install
-sudo rpm -i BOSS-*.rpm
-# OR for Fedora: sudo dnf install BOSS-*.rpm
+sudo rpm -i boss-latest.rpm
+# OR for Fedora: sudo dnf install boss-latest.rpm
 
 # Launch
 boss
@@ -220,9 +226,14 @@ boss
 java -version
 
 # Download and run latest JAR
-wget $(curl -s https://api.github.com/repos/risa-labs-inc/BossConsole-Releases/releases/latest | grep "browser_download_url.*\.jar" | cut -d '"' -f 4)
-java -jar BOSS-*.jar
+curl -fL -o boss-latest.jar "https://api.risaboss.com/functions/v1/latest-release?app=boss&download=jar&arch=amd64"
+java -jar boss-latest.jar
 ```
+
+> Pass `-o <name>`, not `-O`. There is no `Content-Disposition` header on these
+> downloads, so `curl -O` would name the file after the URL's last path
+> segment — `latest-release` — rather than the installer. A browser resolves
+> the redirect first and does save `BOSS-<version>-amd64.deb`.
 </details>
 
 ## 🔄 Updates
@@ -244,7 +255,7 @@ brew update && brew upgrade --cask boss
 ```
 
 **Direct Download Users**
-- Download the latest version from [Releases](https://github.com/risa-labs-inc/BossConsole-Releases/releases/latest)
+- Download the latest version from the [table at the top of this page](#-latest-release)
 - Install over existing installation (settings preserved)
 
 > **🍎 Apple Silicon Users**: Version 8.11.4 includes a critical fix for a crash that prevented BOSS from launching on Apple Silicon Macs. If you're experiencing startup crashes, please update to 8.11.4 or later immediately.

--- a/install.bat
+++ b/install.bat
@@ -16,6 +16,14 @@ setlocal EnableDelayedExpansion
 set "GITHUB_REPO=risa-labs-inc/BossConsole-Releases"
 set "GITHUB_RELEASE_URL=https://github.com/%GITHUB_REPO%/releases/download"
 set "GITHUB_API_URL=https://api.github.com/repos/%GITHUB_REPO%/releases/latest"
+
+:: Primary release source. The latest-release edge function needs no API key
+:: and has no rate limit; unauthenticated api.github.com allows 60 requests
+:: per hour per IP, which a shared address or a CI runner can exhaust — and
+:: this script's only recourse then is to fail and ask for /version by hand.
+:: GitHub stays as the fallback on both lookups and downloads.
+set "LATEST_RELEASE_API=https://api.risaboss.com/functions/v1/latest-release?app=boss"
+set "CDN_RELEASE_URL=https://api.risaboss.com/storage/v1/object/public/app-releases/boss"
 set "SCRIPT_VERSION=1.0.0"
 
 set "VERSION="
@@ -87,7 +95,8 @@ if "%ARCH%"=="arm64" (
     set "MSI_FILE=BOSS-%VERSION%.msi"
 )
 
-set "DOWNLOAD_URL=%GITHUB_RELEASE_URL%/v%VERSION%/%MSI_FILE%"
+set "DOWNLOAD_URL=%CDN_RELEASE_URL%/%VERSION%/%MSI_FILE%"
+set "FALLBACK_URL=%GITHUB_RELEASE_URL%/v%VERSION%/%MSI_FILE%"
 set "TEMP_MSI=%TEMP%\%MSI_FILE%"
 
 if "%DRY_RUN%"=="1" (
@@ -96,12 +105,19 @@ if "%DRY_RUN%"=="1" (
     goto :success
 )
 
-:: Download MSI
+:: Download MSI. Both URLs point at the same asset — the CDN copy and the
+:: GitHub release copy — so a bucket that has not caught up, or a version
+:: predating the bucket, still installs.
 echo Downloading from %DOWNLOAD_URL%...
 call :download_file "%DOWNLOAD_URL%" "%TEMP_MSI%"
 if errorlevel 1 (
-    echo Error: Failed to download MSI
-    exit /b 1
+    echo Warning: Download failed; retrying from GitHub
+    echo Downloading from !FALLBACK_URL!...
+    call :download_file "!FALLBACK_URL!" "%TEMP_MSI%"
+    if errorlevel 1 (
+        echo Error: Failed to download MSI
+        exit /b 1
+    )
 )
 
 :: Run installer
@@ -160,22 +176,16 @@ exit /b 0
 :: ============================================================================
 
 :get_latest_version
-:: Try curl first
-where curl >nul 2>&1
-if %errorlevel%==0 (
-    for /f "tokens=*" %%a in ('curl -sL "%GITHUB_API_URL%" 2^>nul ^| findstr /i "tag_name"') do (
-        set "LINE=%%a"
-        for /f "tokens=2 delims=:," %%b in ("!LINE!") do (
-            set "VERSION=%%~b"
-            set "VERSION=!VERSION: =!"
-            set "VERSION=!VERSION:v=!"
-        )
-    )
-    goto :eof
+:: PowerShell does the parsing on both paths. Splitting a one-line JSON body
+:: on delims in batch is far too fragile for a payload that also carries the
+:: full release notes, and PowerShell ships with every supported Windows.
+for /f "tokens=*" %%a in ('powershell -NoProfile -Command "try { (Invoke-RestMethod -Uri '%LATEST_RELEASE_API%' -UseBasicParsing).version } catch { }" 2^>nul') do (
+    set "VERSION=%%a"
 )
+if not "!VERSION!"=="" goto :eof
 
-:: Fallback to PowerShell
-for /f "tokens=*" %%a in ('powershell -NoProfile -Command "(Invoke-RestMethod -Uri '%GITHUB_API_URL%').tag_name -replace '^v',''" 2^>nul') do (
+echo Warning: Could not reach the release API; falling back to GitHub
+for /f "tokens=*" %%a in ('powershell -NoProfile -Command "try { (Invoke-RestMethod -Uri '%GITHUB_API_URL%' -UseBasicParsing).tag_name.TrimStart('v') } catch { }" 2^>nul') do (
     set "VERSION=%%a"
 )
 goto :eof

--- a/install.bat
+++ b/install.bat
@@ -17,11 +17,11 @@ set "GITHUB_REPO=risa-labs-inc/BossConsole-Releases"
 set "GITHUB_RELEASE_URL=https://github.com/%GITHUB_REPO%/releases/download"
 set "GITHUB_API_URL=https://api.github.com/repos/%GITHUB_REPO%/releases/latest"
 
-:: Primary release source. The latest-release edge function needs no API key
-:: and has no rate limit; unauthenticated api.github.com allows 60 requests
-:: per hour per IP, which a shared address or a CI runner can exhaust — and
-:: this script's only recourse then is to fail and ask for /version by hand.
-:: GitHub stays as the fallback on both lookups and downloads.
+:: Primary release source. The latest-release edge function needs no API key and
+:: is not subject to GitHub's rate limit; unauthenticated api.github.com allows
+:: 60 requests per hour per IP, which a shared address or a CI runner can
+:: exhaust — and this script's only recourse then is to fail and ask for
+:: /version by hand. GitHub stays as the fallback on both lookups and downloads.
 set "LATEST_RELEASE_API=https://api.risaboss.com/functions/v1/latest-release?app=boss"
 set "CDN_RELEASE_URL=https://api.risaboss.com/storage/v1/object/public/app-releases/boss"
 set "SCRIPT_VERSION=1.0.0"

--- a/install.ps1
+++ b/install.ps1
@@ -43,11 +43,11 @@ $GitHubRepo = "risa-labs-inc/BossConsole-Releases"
 $GitHubReleaseUrl = "https://github.com/$GitHubRepo/releases/download"
 $GitHubApiUrl = "https://api.github.com/repos/$GitHubRepo/releases/latest"
 
-# Primary release source. The latest-release edge function needs no API key
-# and has no rate limit; unauthenticated api.github.com allows 60 requests
-# per hour per IP, which a shared address or a CI runner can exhaust — and
-# this script's only recourse then is to fail and ask for -Version by hand.
-# GitHub stays as the fallback on both lookups and downloads.
+# Primary release source. The latest-release edge function needs no API key and
+# is not subject to GitHub's rate limit; unauthenticated api.github.com allows
+# 60 requests per hour per IP, which a shared address or a CI runner can
+# exhaust — and this script's only recourse then is to fail and ask for -Version
+# by hand. GitHub stays as the fallback on both lookups and downloads.
 $LatestReleaseApi = "https://api.risaboss.com/functions/v1/latest-release?app=boss"
 $CdnReleaseUrl = "https://api.risaboss.com/storage/v1/object/public/app-releases/boss"
 $ScriptVersion = "1.0.0"

--- a/install.ps1
+++ b/install.ps1
@@ -42,6 +42,14 @@ param(
 $GitHubRepo = "risa-labs-inc/BossConsole-Releases"
 $GitHubReleaseUrl = "https://github.com/$GitHubRepo/releases/download"
 $GitHubApiUrl = "https://api.github.com/repos/$GitHubRepo/releases/latest"
+
+# Primary release source. The latest-release edge function needs no API key
+# and has no rate limit; unauthenticated api.github.com allows 60 requests
+# per hour per IP, which a shared address or a CI runner can exhaust — and
+# this script's only recourse then is to fail and ask for -Version by hand.
+# GitHub stays as the fallback on both lookups and downloads.
+$LatestReleaseApi = "https://api.risaboss.com/functions/v1/latest-release?app=boss"
+$CdnReleaseUrl = "https://api.risaboss.com/storage/v1/object/public/app-releases/boss"
 $ScriptVersion = "1.0.0"
 
 # ============================================================================
@@ -91,12 +99,24 @@ function Get-Architecture {
 
 function Get-LatestVersion {
     try {
+        $response = Invoke-RestMethod -Uri $LatestReleaseApi -UseBasicParsing
+        if ($response.version) {
+            return $response.version
+        }
+        throw "response contained no version"
+    }
+    catch {
+        Write-Warn "Could not reach the release API ($_); falling back to GitHub"
+    }
+
+    try {
         $response = Invoke-RestMethod -Uri $GitHubApiUrl -UseBasicParsing
         $version = $response.tag_name -replace '^v', ''
         return $version
     }
     catch {
         Write-Err "Failed to fetch latest version: $_"
+        Write-Err "Specify a version explicitly with -Version"
         exit 1
     }
 }
@@ -118,7 +138,8 @@ function Install-BOSS {
         $msiFileName = "BOSS-$Version.msi"
     }
 
-    $downloadUrl = "$GitHubReleaseUrl/v$Version/$msiFileName"
+    $downloadUrl = "$CdnReleaseUrl/$Version/$msiFileName"
+    $fallbackUrl = "$GitHubReleaseUrl/v$Version/$msiFileName"
     $tempPath = Join-Path $env:TEMP $msiFileName
 
     Write-Info "Installing BOSS version $Version ($Arch)..."
@@ -129,14 +150,23 @@ function Install-BOSS {
         return
     }
 
-    # Download MSI
+    # Download MSI. Both URLs point at the same asset — the CDN copy and the
+    # GitHub release copy — so a bucket that has not caught up, or a version
+    # predating the bucket, still installs.
     Write-Info "Downloading from $downloadUrl"
     try {
         Invoke-WebRequest -Uri $downloadUrl -OutFile $tempPath -UseBasicParsing
     }
     catch {
-        Write-Err "Failed to download MSI: $_"
-        exit 1
+        Write-Warn "Download failed ($_); retrying from GitHub"
+        Write-Info "Downloading from $fallbackUrl"
+        try {
+            Invoke-WebRequest -Uri $fallbackUrl -OutFile $tempPath -UseBasicParsing
+        }
+        catch {
+            Write-Err "Failed to download MSI: $_"
+            exit 1
+        }
     }
 
     # Run MSI installer

--- a/install.sh
+++ b/install.sh
@@ -24,11 +24,11 @@ GITHUB_REPO="risa-labs-inc/BossConsole-Releases"
 GITHUB_RELEASE_URL="https://github.com/${GITHUB_REPO}/releases/download"
 GITHUB_API_URL="https://api.github.com/repos/${GITHUB_REPO}/releases/latest"
 
-# Primary release source. The latest-release edge function needs no API key
-# and has no rate limit; unauthenticated api.github.com allows 60 requests
-# per hour per IP, which a shared address or a CI runner can exhaust — and
-# this script's only recourse then is to tell the user to pass --version by
-# hand. GitHub stays as the fallback on both lookups and downloads.
+# Primary release source. The latest-release edge function needs no API key and
+# is not subject to GitHub's rate limit; unauthenticated api.github.com allows
+# 60 requests per hour per IP, which a shared address or a CI runner can
+# exhaust — and this script's only recourse then is to tell the user to pass
+# --version by hand. GitHub stays as the fallback on both lookups and downloads.
 LATEST_RELEASE_API="https://api.risaboss.com/functions/v1/latest-release?app=boss"
 CDN_RELEASE_URL="https://api.risaboss.com/storage/v1/object/public/app-releases/boss"
 
@@ -187,7 +187,7 @@ get_latest_version() {
     # Refuse anything that is not a bare version. This function's stdout is its
     # return value, so any stray output here would otherwise be pasted into a
     # download URL and fail much later with an unrecognisable message.
-    if ! echo "$version" | grep -qE '^[0-9]+\.[0-9]+\.[0-9]+'; then
+    if ! echo "$version" | grep -qE '^[0-9]+\.[0-9]+\.[0-9]+(-(alpha|beta|rc)\.[0-9]+)?$'; then
         error "Resolved version is not a version number: '$version'"
         error "Please specify a version with --version"
         exit 1

--- a/install.sh
+++ b/install.sh
@@ -69,8 +69,11 @@ success() {
     echo -e "${GREEN}==>${NC} ${BOLD}$1${NC}"
 }
 
+# Diagnostics go to stderr, like error(). get_latest_version's stdout IS its
+# return value, so a warning on stdout would be captured into the version
+# string and produce a download URL built from the warning text.
 warn() {
-    echo -e "${YELLOW}Warning:${NC} $1"
+    echo -e "${YELLOW}Warning:${NC} $1" >&2
 }
 
 error() {
@@ -181,6 +184,15 @@ get_latest_version() {
         exit 1
     fi
 
+    # Refuse anything that is not a bare version. This function's stdout is its
+    # return value, so any stray output here would otherwise be pasted into a
+    # download URL and fail much later with an unrecognisable message.
+    if ! echo "$version" | grep -qE '^[0-9]+\.[0-9]+\.[0-9]+'; then
+        error "Resolved version is not a version number: '$version'"
+        error "Please specify a version with --version"
+        exit 1
+    fi
+
     echo "$version"
 }
 
@@ -222,6 +234,10 @@ download_file() {
         if fetch_to_file "$fallback_url" "$output"; then
             return 0
         fi
+        error "Failed to download from both sources:"
+        error "  $url"
+        error "  $fallback_url"
+        exit 1
     fi
 
     error "Failed to download $url"

--- a/install.sh
+++ b/install.sh
@@ -24,6 +24,14 @@ GITHUB_REPO="risa-labs-inc/BossConsole-Releases"
 GITHUB_RELEASE_URL="https://github.com/${GITHUB_REPO}/releases/download"
 GITHUB_API_URL="https://api.github.com/repos/${GITHUB_REPO}/releases/latest"
 
+# Primary release source. The latest-release edge function needs no API key
+# and has no rate limit; unauthenticated api.github.com allows 60 requests
+# per hour per IP, which a shared address or a CI runner can exhaust — and
+# this script's only recourse then is to tell the user to pass --version by
+# hand. GitHub stays as the fallback on both lookups and downloads.
+LATEST_RELEASE_API="https://api.risaboss.com/functions/v1/latest-release?app=boss"
+CDN_RELEASE_URL="https://api.risaboss.com/storage/v1/object/public/app-releases/boss"
+
 # Installation paths
 MACOS_APP_PATH="/Applications/BOSS.app"
 CLI_SYSTEM_PATH="/usr/local/bin/boss"
@@ -143,12 +151,29 @@ as_root() {
 # Version Management
 # ============================================================================
 
+fetch_url() {
+    local url="$1"
+    if has_command curl; then
+        curl -sL "$url" 2>/dev/null
+    elif has_command wget; then
+        wget -qO- "$url" 2>/dev/null
+    fi
+}
+
 get_latest_version() {
     local version
-    if has_command curl; then
-        version=$(curl -sL "$GITHUB_API_URL" 2>/dev/null | grep '"tag_name"' | sed -E 's/.*"v([^"]+)".*/\1/' | head -1)
-    elif has_command wget; then
-        version=$(wget -qO- "$GITHUB_API_URL" 2>/dev/null | grep '"tag_name"' | sed -E 's/.*"v([^"]+)".*/\1/' | head -1)
+
+    # The edge function answers with {"app":"boss","version":"X.Y.Z",...}.
+    # `release_notes` in that payload escapes its own quotes, so a literal
+    # "version": inside the notes cannot match this pattern.
+    version=$(fetch_url "$LATEST_RELEASE_API" \
+        | grep -o '"version"[[:space:]]*:[[:space:]]*"[^"]*"' \
+        | head -1 \
+        | sed -E 's/.*"([^"]+)"$/\1/')
+
+    if [ -z "$version" ]; then
+        warn "Could not reach the release API; falling back to GitHub"
+        version=$(fetch_url "$GITHUB_API_URL" | grep '"tag_name"' | sed -E 's/.*"v([^"]+)".*/\1/' | head -1)
     fi
 
     if [ -z "$version" ]; then
@@ -163,20 +188,44 @@ get_latest_version() {
 # Download Helpers
 # ============================================================================
 
-download_file() {
+fetch_to_file() {
     local url="$1"
     local output="$2"
 
-    info "Downloading from $url"
-
     if has_command curl; then
-        curl -fsSL --progress-bar "$url" -o "$output"
+        curl -fL --progress-bar "$url" -o "$output"
     elif has_command wget; then
         wget -q --show-progress "$url" -O "$output"
     else
         error "Neither curl nor wget found. Please install one of them."
         exit 1
     fi
+}
+
+# Downloads $1, falling back to $3 if given. Both point at the same asset —
+# the CDN copy and the GitHub release copy — so a bucket that has not caught
+# up, or a version predating the bucket, still installs.
+download_file() {
+    local url="$1"
+    local output="$2"
+    local fallback_url="${3:-}"
+
+    info "Downloading from $url"
+
+    if fetch_to_file "$url" "$output"; then
+        return 0
+    fi
+
+    if [ -n "$fallback_url" ]; then
+        warn "Download failed; retrying from GitHub"
+        info "Downloading from $fallback_url"
+        if fetch_to_file "$fallback_url" "$output"; then
+            return 0
+        fi
+    fi
+
+    error "Failed to download $url"
+    exit 1
 }
 
 # ============================================================================
@@ -206,7 +255,9 @@ check_installed() {
 
 install_macos_dmg() {
     local version="$1"
-    local dmg_url="${GITHUB_RELEASE_URL}/v${version}/BOSS-${version}-Universal.dmg"
+    local asset="BOSS-${version}-Universal.dmg"
+    local dmg_url="${CDN_RELEASE_URL}/${version}/${asset}"
+    local dmg_fallback_url="${GITHUB_RELEASE_URL}/v${version}/${asset}"
     local tmp_dmg
     local mount_point
 
@@ -222,7 +273,7 @@ install_macos_dmg() {
     tmp_dmg=$(mktemp /tmp/BOSS-XXXXXX.dmg)
 
     # Download Universal DMG (works on Apple Silicon and Intel via Rosetta 2)
-    download_file "$dmg_url" "$tmp_dmg"
+    download_file "$dmg_url" "$tmp_dmg" "$dmg_fallback_url"
 
     # Mount DMG
     info "Mounting DMG..."
@@ -260,7 +311,9 @@ install_macos_dmg() {
 install_linux_deb() {
     local version="$1"
     local arch="$2"
-    local deb_url="${GITHUB_RELEASE_URL}/v${version}/BOSS-${version}-${arch}.deb"
+    local asset="BOSS-${version}-${arch}.deb"
+    local deb_url="${CDN_RELEASE_URL}/${version}/${asset}"
+    local deb_fallback_url="${GITHUB_RELEASE_URL}/v${version}/${asset}"
     local tmp_deb
 
     info "Installing BOSS from Deb package (version ${version}, arch ${arch})..."
@@ -275,7 +328,7 @@ install_linux_deb() {
     tmp_deb=$(mktemp /tmp/boss-XXXXXX.deb)
 
     # Download Deb
-    download_file "$deb_url" "$tmp_deb"
+    download_file "$deb_url" "$tmp_deb" "$deb_fallback_url"
 
     # Install
     info "Installing package..."
@@ -298,7 +351,9 @@ install_linux_rpm() {
     local version="$1"
     local arch="$2"
     local rpm_arch
+    local asset
     local rpm_url
+    local rpm_fallback_url
     local tmp_rpm
 
     # Map architecture
@@ -311,7 +366,9 @@ install_linux_rpm() {
             ;;
     esac
 
-    rpm_url="${GITHUB_RELEASE_URL}/v${version}/BOSS-${version}-${arch}.rpm"
+    asset="BOSS-${version}-${arch}.rpm"
+    rpm_url="${CDN_RELEASE_URL}/${version}/${asset}"
+    rpm_fallback_url="${GITHUB_RELEASE_URL}/v${version}/${asset}"
 
     info "Installing BOSS from RPM package (version ${version}, arch ${rpm_arch})..."
 
@@ -325,7 +382,7 @@ install_linux_rpm() {
     tmp_rpm=$(mktemp /tmp/boss-XXXXXX.rpm)
 
     # Download RPM
-    download_file "$rpm_url" "$tmp_rpm"
+    download_file "$rpm_url" "$tmp_rpm" "$rpm_fallback_url"
 
     # Install
     info "Installing package..."


### PR DESCRIPTION
## Why

Every cell in the "🚀 Latest Release" table linked to the releases *page* — seven links, one destination — leaving the reader to pick the right asset out of thirteen. Windows ARM64 and Linux ARM64 were listed but not separately reachable.

The Linux instructions were worse. They resolved the download by piping `api.github.com` through `grep browser_download_url`, inheriting the **60 requests/hour per IP** unauthenticated limit. Past that ceiling the substitution yields nothing and `wget $(...)` runs with an empty argument.

The three install scripts had the same ceiling on their version lookup, and their only recourse when it hit was to tell the user to pass `--version` by hand.

## What changed

**README** — each package links directly through the `latest-release` edge function, split by architecture:

| Platform | Arch | Packages |
|---|---|---|
| macOS | Universal | DMG (+ Homebrew) |
| Windows | x64 / ARM64 | MSI each |
| Linux | AMD64 / ARM64 | DEB · RPM · JAR each |

No API key, no rate limit, resolved server-side per request, so the link cannot go stale.

Documented the two query flags against the function source rather than from memory — worth stating because I had it backwards at first: `&prerelease=true` **includes** prereleases (they are excluded by default) rather than selecting one, and `&channel=beta|alpha|rc` tracks a single channel.

**install.sh / install.ps1 / install.bat** — resolve "latest" through the edge function, with GitHub as fallback on *both* the version lookup and the asset download. Pinned `--version` installs keep working: the bucket has per-version paths (verified against 9.2.64), and GitHub covers any version predating it.

`install.bat` now parses both responses with PowerShell. The old `for /f "tokens=2 delims=:,"` approach cannot survive a JSON body that also carries the full release notes, and PowerShell ships with every supported Windows.

**Corrected the download commands to `curl -o`, not `-O`.** These redirects carry no `Content-Disposition`, so `-O` names the file after the URL's last path segment — `latest-release`, no extension — and the install then fails on a file `dpkg` won't recognise. Verified:

```
$ curl -fsSL -O "…?app=boss&download=deb&arch=amd64"   → latest-release
$ curl -fsSL -o boss-latest.deb "…"                     → Debian binary package (format 2.0)
```

A browser resolves the redirect first and does save `BOSS-9.4.0-amd64.deb`; CLI tools don't.

## What I deliberately did not change

`update-distribution.yml` keeps its **pinned, versioned** URL. A Homebrew cask pairs `url` with `sha256`, so it cannot point at a moving target — an always-latest link is unusable there by construction.

GitHub also stays its **primary** source, which is the opposite of the change everywhere else. This job triggers on `release: published`, and in `sync-release.yml` the "Create public release" step (L250) runs *before* "Publish release to Supabase Storage" (L323) — so when this fires, the CDN copy may not exist yet. It gains the CDN only as a fallback, plus `set -euo pipefail`, which it was missing.

## Verification

`bash -n` clean and `shellcheck -S warning` clean — the same gate CI applies. Both workflow YAMLs parse.

Dry-runs resolve through the new path:

```
==> Fetching latest version...
==> Installing BOSS version 9.4.0
==> [DRY-RUN] Would download: …/app-releases/boss/9.4.0/BOSS-9.4.0-Universal.dmg

--version 9.2.64 → …/app-releases/boss/9.2.64/BOSS-9.2.64-Universal.dmg
```

Sourced the script's functions and exercised the failure paths directly — 12/12:

```
--- get_latest_version: edge function is primary ---
PASS  resolves a semver from the edge fn
--- edge fn unreachable -> GitHub fallback ---
PASS  warns about the fallback
PASS  still resolves a semver
PASS  both sources agree
--- BOTH unreachable -> hard error, no silent empty ---
PASS  exits nonzero
PASS  tells the user to pass --version
--- download_file: primary 404 -> fallback used ---
PASS  returns success via fallback
PASS  warns before retrying
PASS  file actually has content
--- no fallback given, primary 404 -> exits ---
PASS  exits nonzero
PASS  reports the failed url
--- both 404 -> exits, does not claim success ---
PASS  exits nonzero
```

All 10 README links return 200/302, each resolving to a real 9.4.0 asset (a 9.4.0 release shipped mid-review; the links tracked it with no edit, which is the point).

`install.ps1` and `install.bat` could not be run locally — no PowerShell on this machine. `test-install.yml` covers them on a real Windows runner and is triggered by this PR's paths.

## Unrelated pre-existing bug, not fixed here

`install.sh:672` guards the "already installed" prompt on `$FORCE`, but no flag ever sets it and it is never initialised — so the prompt always fires. Under the documented `curl … | bash` one-liner the script *is* bash's stdin, so `read` consumes the next line of the script rather than user input. That makes upgrade-in-place via the documented command unreliable. Left alone since fixing it changes install semantics and deserves its own decision.
