### PR TITLE
Make the install prompt work under curl | bash

### DIFF
--- a/.github/workflows/test-install.yml
+++ b/.github/workflows/test-install.yml
@@ -114,9 +114,35 @@ jobs:
           echo "$OUTPUT" | grep -qE 'Installing BOSS version [0-9]+\.[0-9]+\.[0-9]+'
           echo "$OUTPUT" | grep -q 'app-releases/boss/'
 
+      # Guards the "already installed" prompt against the failure it shipped
+      # with: FORCE gated it but no flag ever set it, so the prompt always
+      # fired, and under `set -e` a read that hits EOF kills the script. An
+      # unattended upgrade therefore stopped at the warning with exit 1 — and
+      # under the documented `curl … | bash`, read consumed the script itself.
+      # Every job above runs on a clean runner where BOSS is absent, so nothing
+      # reached this branch; a fake `boss` on PATH satisfies check_installed.
+      - name: Test unattended run with BOSS already installed
+        run: |
+          mkdir -p /tmp/fakebin
+          printf '#!/bin/sh\n' > /tmp/fakebin/boss && chmod +x /tmp/fakebin/boss
+
+          OUTPUT=$(PATH="/tmp/fakebin:$PATH" ./install.sh --dry-run --version 8.15.10 </dev/null 2>&1)
+          echo "$OUTPUT"
+          echo "$OUTPUT" | grep -q "already installed"
+          # The assertion that matters: it got PAST the prompt. The old code
+          # died at the read, so this line was never printed.
+          echo "$OUTPUT" | grep -q "Would download"
+          echo "$OUTPUT" | grep -q "No terminal to prompt on"
+
+          # --force answers it up front, with no notice at all.
+          FORCED=$(PATH="/tmp/fakebin:$PATH" ./install.sh --dry-run --version 8.15.10 --force </dev/null 2>&1)
+          echo "$FORCED"
+          echo "$FORCED" | grep -q "Would download"
+          ! echo "$FORCED" | grep -q "No terminal to prompt on"
+
       - name: Test install (real)
         if: github.event_name == 'release' || github.event.inputs.run_real_install == 'true'
-        run: ./install.sh
+        run: ./install.sh --force
 
       - name: Verify installation
         if: github.event_name == 'release' || github.event.inputs.run_real_install == 'true'

--- a/README.md
+++ b/README.md
@@ -126,9 +126,18 @@ curl -fsSL .../install.sh | bash -s -- --version 8.15.10
 # Dry run (preview without installing)
 curl -fsSL .../install.sh | bash -s -- --dry-run
 
+# Reinstall over an existing install without being asked
+curl -fsSL .../install.sh | bash -s -- --force
+
 # Uninstall
 curl -fsSL .../install.sh | bash -s -- --uninstall
 ```
+
+Upgrading over an existing install is the normal path and needs no flag: when
+there is a terminal you are asked to confirm, and when there isn't — a CI step,
+a provisioning script — it proceeds. `--force` skips the question outright. It
+never removes your configuration; an uninstall only does that if you confirm it
+at a terminal.
 
 #### Windows (PowerShell)
 ```powershell

--- a/install.sh
+++ b/install.sh
@@ -41,6 +41,15 @@ CONFIG_PATH="${HOME}/.boss"
 # Script version
 SCRIPT_VERSION="1.0.0"
 
+# Flags. These were only ever assigned inside the argument parser and compared
+# with `[ "$X" = true ]`, which happens to work unset because there is no
+# `set -u` — FORCE had no flag setting it at all, so its guard was dead and the
+# prompt it guarded always fired. Declared here so each one has exactly one
+# obvious default.
+DRY_RUN=false
+SKIP_CLI=false
+FORCE=false
+
 # ============================================================================
 # Colors and Output
 # ============================================================================
@@ -121,6 +130,56 @@ detect_distro() {
 
 has_command() {
     command -v "$1" >/dev/null 2>&1
+}
+
+# Ask a [y/N] question. Echoes "yes", "no", or "unattended" when there is
+# nobody to ask. Callers choose what "unattended" means for their question.
+#
+# A bare `read` is wrong here in three separate ways, and the primary install
+# path hits all of them:
+#
+#   * `curl … | bash` makes the SCRIPT bash's stdin, so `read` consumes the
+#     script's own next line as the answer rather than anything a user typed.
+#   * Under `set -e`, a `read` that reaches EOF returns non-zero and kills the
+#     script on the spot — which is why the "Installation cancelled" branch was
+#     unreachable and an unattended upgrade simply stopped with exit 1 after
+#     announcing that BOSS was already installed.
+#   * With stdin an open pipe that never delivers (a CI step, a wrapper script),
+#     `read` blocks forever.
+#
+# So: read from stdin when it is a terminal, otherwise from the controlling
+# terminal if there is one — that is the `curl … | bash` case, where a human IS
+# present but stdin is the script. Only when neither exists is there truly
+# nobody to ask.
+#
+# `( : </dev/tty )` and not `exec 3</dev/tty`: a failed redirection on `exec`
+# terminates a non-interactive shell, so probing that way would kill the
+# installer on exactly the machines that have no controlling terminal. The
+# subshell absorbs the failure instead.
+#
+# The prompt is written to stderr explicitly rather than via `read -p`, because
+# this function's stdout is its return value.
+confirm() {
+    local prompt="$1"
+    local reply=""
+
+    if [ -t 0 ]; then
+        printf '%s' "$prompt" >&2
+        read -r -n 1 reply || reply=""
+        printf '\n' >&2
+    elif ( : </dev/tty ) 2>/dev/null; then
+        printf '%s' "$prompt" >&2
+        read -r -n 1 reply </dev/tty || reply=""
+        printf '\n' >&2
+    else
+        echo "unattended"
+        return 0
+    fi
+
+    case "$reply" in
+        [Yy]) echo "yes" ;;
+        *)    echo "no" ;;
+    esac
 }
 
 has_sudo() {
@@ -556,17 +615,24 @@ uninstall() {
         success "Removed user CLI launcher"
     fi
 
-    # Ask about config
+    # Ask about config. Deliberately the opposite default to the install
+    # prompt: an unattended install should proceed, but nothing unattended
+    # should delete the user's data. --force does not apply here either — "stop
+    # asking whether to upgrade" is not "delete my configuration".
     if [ -d "$CONFIG_PATH" ]; then
         echo ""
-        read -p "Remove configuration at $CONFIG_PATH? [y/N] " -n 1 -r
-        echo ""
-        if [[ $REPLY =~ ^[Yy]$ ]]; then
-            rm -rf "$CONFIG_PATH"
-            success "Removed configuration"
-        else
-            info "Configuration preserved at $CONFIG_PATH"
-        fi
+        case "$(confirm "Remove configuration at $CONFIG_PATH? [y/N] ")" in
+            yes)
+                rm -rf "$CONFIG_PATH"
+                success "Removed configuration"
+                ;;
+            unattended)
+                info "No terminal to prompt on; configuration preserved at $CONFIG_PATH"
+                ;;
+            *)
+                info "Configuration preserved at $CONFIG_PATH"
+                ;;
+        esac
     fi
 
     success "BOSS uninstalled successfully"
@@ -589,6 +655,8 @@ Options:
     --uninstall          Uninstall BOSS
     --dry-run            Show what would be done without making changes
     --skip-cli           Skip CLI launcher installation
+    --force, -f, -y      Do not ask before reinstalling over an existing
+                         install. Never removes configuration.
     --help               Show this help message
 
 Examples:
@@ -641,6 +709,10 @@ main() {
                 SKIP_CLI=true
                 shift
                 ;;
+            --force|-f|--yes|-y)
+                FORCE=true
+                shift
+                ;;
             --help|-h)
                 show_usage
                 ;;
@@ -686,12 +758,21 @@ main() {
     if check_installed "$os"; then
         warn "BOSS appears to be already installed"
         if [ "$FORCE" != true ]; then
-            read -p "Continue with installation? [y/N] " -n 1 -r
-            echo ""
-            if [[ ! $REPLY =~ ^[Yy]$ ]]; then
-                info "Installation cancelled"
-                exit 0
-            fi
+            case "$(confirm 'Continue with installation? [y/N] ')" in
+                yes)
+                    ;;
+                unattended)
+                    # Installing over an existing install IS the documented
+                    # upgrade path, and an unattended invocation asked for an
+                    # install. Refusing here is what made the `curl … | bash`
+                    # one-liner unusable for upgrades.
+                    info "No terminal to prompt on; continuing with the upgrade (--force to silence)"
+                    ;;
+                *)
+                    info "Installation cancelled"
+                    exit 0
+                    ;;
+            esac
         fi
     fi
 


### PR DESCRIPTION
## The bug

`FORCE` appeared **exactly once** in the entire script — the comparison itself:

```bash
if [ "$FORCE" != true ]; then
    read -p "Continue with installation? [y/N] " -n 1 -r
```

No flag set it, and it was never initialised. So the guard was dead and the prompt always fired. That `read` then fails three different ways depending on invocation, and the documented install path hits the worst:

| Invocation | What happens |
|---|---|
| `curl … \| bash` | The **script** is bash's stdin, so `read` consumes the script's own next line as the answer |
| stdin at EOF | `read` returns non-zero → **`set -e` (line 17) kills the script** |
| stdin an open pipe | `read` **blocks forever** |

I reproduced all three before touching anything — including the hang.

The `set -e` interaction is the reason this was invisible: **"Installation cancelled" never printed**, because the script died at the `read` before reaching it. An unattended upgrade just stopped after announcing BOSS was already installed, with exit 1 and no explanation:

```
$ bash install.sh --dry-run </dev/null
==> Installing BOSS version 9.4.0
Warning: BOSS appears to be already installed
$ echo $?
1
```

So `curl -fsSL …/install.sh | bash` — the command in this repo's README and on the website — could not upgrade an existing install.

## The fix

One `confirm` helper, used by both prompts:

- stdin is a terminal → read stdin (plain `./install.sh`)
- stdin is not → read **`/dev/tty`**. This is the `curl … | bash` case, where a human *is* present but stdin is the script. It's the main documented path, and it now prompts properly instead of dying.
- neither → `unattended`, and the caller decides what that means

Two details worth calling out:

- It probes with `( : </dev/tty )`, **not** `exec 3</dev/tty`. A failed redirection on `exec` terminates a non-interactive shell, so probing that way would kill the installer on exactly the machines that have no controlling terminal. The subshell absorbs the failure.
- The prompt is written to stderr explicitly rather than via `read -p`, because the helper's stdout is its return value. (This is the same shape as the `warn()`-on-stdout bug from #19, so I checked it rather than assumed it.)

**The two callers default opposite ways, deliberately.** An unattended *install* proceeds — installing over an existing install is the documented upgrade path, and the invocation asked for an install. An unattended *uninstall* preserves configuration, because nothing unattended should delete a user's data. `--force` doesn't extend to it either: "stop asking whether to upgrade" is not "delete my configuration".

`--force` / `-f` / `--yes` / `-y` now exists. `DRY_RUN` and `SKIP_CLI` were also only ever assigned inside the parser, so all three are declared with defaults instead of relying on `set -u` being absent.

## Verification

Every path, not just the broken ones. Interactive cases driven over a **real pty** (`pty.fork`), with `confirm`'s stdout captured to a file so the terminal carries only the prompt:

```
PASS  interactive, answer y                  value='yes'  prompt_on_terminal=True  leaked_into_value=False
PASS  interactive, answer n                  value='no'   prompt_on_terminal=True  leaked_into_value=False
PASS  interactive, answer garbage            value='no'   prompt_on_terminal=True  leaked_into_value=False
PASS  curl|bash: stdin=script, tty exists    value='yes'  prompt_on_terminal=True  leaked_into_value=False
```

End-to-end on the real script over a pty:

```
PASS  answered 'n': prompted=True proceeded=False cancelled=True
PASS  answered 'y': prompted=True proceeded=True  cancelled=False
```

Non-interactive, previously broken:

```
stdin at EOF          exit=0, "No terminal to prompt on; continuing with the upgrade", proceeds
curl | bash shape     exit=0, same
--force               exit=0, proceeds with no notice at all
```

`uninstall()` returns early under `--dry-run`, before the config prompt, so the real script can't exercise it without actually uninstalling. I extracted the **shipped lines** for that block and ran them against a throwaway config dir:

```
==> No terminal to prompt on; configuration preserved at …/fakecfg
throwaway config still present: YES-preserved
```

## CI guard

Added on ubuntu with a fake `boss` on `PATH`. Worth noting *why* this was needed: every existing job runs on a clean runner where BOSS is absent, so `check_installed` was false and **nothing in CI ever reached this branch** — the same blind spot as the pinned `--version` dry-runs in #19.

Confirmed it fails against the pre-fix script (`git stash`, re-run): old code exits 1 and never reaches "Would download", so the assertion trips.

## Behaviour change

A piped answer is no longer read, since stdin isn't a trustworthy answer source here. `echo y | install.sh --uninstall` used to delete configuration and now preserves it. Install needs no piped answer any more, because unattended runs proceed on their own. If you want unattended config removal, that wants an explicit `--purge` — happy to add it, but it shouldn't ride on `--force`.
