### PR TITLE
Stop cutting a plugin release for a docs-only push

### DIFF
--- a/.github/workflows/plugin-release.yml
+++ b/.github/workflows/plugin-release.yml
@@ -20,7 +20,76 @@ on:
         required: false
 
 jobs:
+  # Every plugin's build.yml fires this on any push to main with no path filter,
+  # and a release means: bump the version, delete and recreate the GitHub
+  # release, and publish to the Plugin Store. So a README typo used to offer
+  # every BOSS user a plugin update that changed nothing they can run.
+  #
+  # Fails toward releasing. If the previous commit cannot be resolved (a new
+  # branch, a force-push) or the event is not a push, this releases: a redundant
+  # release is cheap, a silently skipped one is not.
+  detect:
+    name: Decide whether this push needs a release
+    runs-on: ubuntu-latest
+    outputs:
+      docs_only: ${{ steps.check.outputs.docs_only }}
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          # Needed to diff against the pushed-from commit.
+          fetch-depth: 0
+
+      - name: Check whether the push is docs-only
+        id: check
+        run: |
+          set -euo pipefail
+
+          release() { echo "docs_only=false" >> "$GITHUB_OUTPUT"; }
+
+          if [[ "${{ github.event_name }}" != "push" ]]; then
+            echo "Event is ${{ github.event_name }}, not a push - releasing."
+            release; exit 0
+          fi
+
+          BEFORE="${{ github.event.before }}"
+          if [[ -z "$BEFORE" || "$BEFORE" =~ ^0+$ ]] || ! git cat-file -e "${BEFORE}^{commit}" 2>/dev/null; then
+            echo "::notice::Cannot resolve the previous commit; releasing rather than guessing."
+            release; exit 0
+          fi
+
+          # git diff --name-only is already one path per line. Keep it quoted:
+          # relying on word-splitting would break on a path containing a space,
+          # and it silently collapses to a single line in shells that do not
+          # split (which is how a test of this predicate first misled me).
+          CHANGED=$(git diff --name-only "$BEFORE" "${{ github.sha }}")
+          echo "Changed files:"
+          printf '%s\n' "$CHANGED" | sed 's/^/  /'
+
+          if [[ -z "$CHANGED" ]]; then
+            echo "::notice::No file changes detected; releasing."
+            release; exit 0
+          fi
+
+          # Deliberately conservative: only these count as prose. Anything else,
+          # including build files, resources and source, is a real change.
+          # The LICENSE/NOTICE alternatives are spelled out rather than using
+          # `(^|/)`, whose behaviour differs between grep implementations.
+          NON_DOCS=$(printf '%s\n' "$CHANGED" \
+            | grep -vE '\.(md|txt)$|^docs/|^(LICENSE|NOTICE)$|/(LICENSE|NOTICE)$' || true)
+
+          if [[ -z "$NON_DOCS" ]]; then
+            echo "docs_only=true" >> "$GITHUB_OUTPUT"
+            echo "::notice::Docs-only push - skipping the release. Use workflow_dispatch to force one."
+          else
+            echo "Non-docs changes present:"
+            printf '%s\n' "$NON_DOCS" | sed 's/^/  /'
+            release
+          fi
+
   release:
+    needs: detect
+    if: needs.detect.outputs.docs_only != 'true'
     runs-on: ubuntu-latest
     steps:
       - name: Checkout


### PR DESCRIPTION
Every plugin's `build.yml` calls this workflow on **any** push to `main` with no path filter, and a release here means:

```
Bump version -> Delete existing release -> Create GitHub Release -> Publish to BOSS Plugin Store
```

So a README typo offers every BOSS user a plugin update that changes nothing they can run. This came up because an em-dash sweep across 35 plugins would otherwise produce **35 version bumps and 35 store publishes** for hyphens.

## What changed

A `detect` job classifies the push; `release` is gated on it.

**It fails toward releasing.** A non-push event, an unresolvable previous commit (new branch, force-push), or an empty diff all release - a redundant release is cheap, a silently skipped one is not. `workflow_dispatch` stays as the manual override.

Only `.md`, `.txt`, `docs/` and `LICENSE`/`NOTICE` count as prose. Build files, resources, `plugin.json` and source are real changes, and a push mixing docs with any of them releases.

## Two details the tests forced

- **`"$CHANGED"` stays quoted.** Unquoted it breaks on a path containing a space, and in a shell that does not word-split it collapses to a single line. That is exactly how my first test misled me into thinking a doc+source push would skip.
- **`LICENSE`/`NOTICE` alternatives are spelled out** rather than using `(^|/)`, whose behaviour is not consistent across grep implementations. A check that means one thing locally and another on the runner is worse than no check.

## Verification

13 cases under bash, matching the runner:

```
README.md                        SKIP     3 doc files              SKIP
docs/design-system.html          SKIP     LICENSE + NOTICE         SKIP
nested/LICENSE                   SKIP     docs only, path w/ space SKIP
one .kt                          RELEASE  build.gradle.kts         RELEASE
doc + .kt  (the dangerous one)   RELEASE  plugin.json              RELEASE
doc + kt + gradle                RELEASE  resources                RELEASE
path with a space + kt           RELEASE
```

I will confirm the skip on a real plugin push before sweeping the rest.