### PR TITLE
ci: let the version bump push with an org-admin token

### DIFF
--- a/.github/workflows/plugin-release.yml
+++ b/.github/workflows/plugin-release.yml
@@ -18,6 +18,16 @@ on:
         required: true
       SUPABASE_ANON_KEY:
         required: false
+      # The version bump pushes straight to main. GITHUB_TOKEN runs as the
+      # github-actions app, which is a built-in rather than an org installation,
+      # so it cannot be named as a bypass actor on a ruleset and its push is
+      # refused once main requires a pull request. A token belonging to an org
+      # admin is covered by the OrganizationAdmin bypass and pushes fine.
+      #
+      # Optional on purpose: callers that have not been given the secret yet
+      # fall back to GITHUB_TOKEN below and keep working exactly as before.
+      PLUGIN_RELEASE_TOKEN:
+        required: false
 
 jobs:
   # Every plugin's build.yml fires this on any push to main with no path filter,
@@ -95,7 +105,10 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v4
         with:
-          token: ${{ secrets.GITHUB_TOKEN }}
+          # Falls back to GITHUB_TOKEN so a caller that has not been handed
+          # PLUGIN_RELEASE_TOKEN yet behaves exactly as it did before. Only
+          # repos whose main is ruleset-protected actually need the override.
+          token: ${{ secrets.PLUGIN_RELEASE_TOKEN || secrets.GITHUB_TOKEN }}
 
       - name: Bump version
         if: inputs.version_increment != 'none'


### PR DESCRIPTION
## Why

Branch protection is being rolled out across the plugin repos. The blocker is the version bump in this workflow, which pushes directly to `main`.

`GITHUB_TOKEN` runs as the `github-actions` app. That app is a GitHub built-in, not an installation in `risa-labs-inc`, so it cannot be named as a ruleset bypass actor:

```
422 Validation Failed
Actor GitHub Actions integration must be part of the ruleset source or owner organization
```

Both "require a pull request" and "require status checks" block direct pushes, and `enforce_admins: false` exempts admins only - `GITHUB_TOKEN` is not an admin. So the moment a plugin's `main` is protected, the bump is rejected and the `release` job fails on its first real step.

## What changed

`PLUGIN_RELEASE_TOKEN` is added as an **optional** `workflow_call` secret, and the `release` checkout uses it when present:

```yaml
token: ${{ secrets.PLUGIN_RELEASE_TOKEN || secrets.GITHUB_TOKEN }}
```

A token owned by an org admin is covered by the `OrganizationAdmin` bypass and pushes fine.

## Safe to merge now

The secret is optional and the fallback is the current behaviour, so callers that have not been given it are completely unaffected. Nothing needs to be sequenced around this merge.

## Follow-up

- Add `PLUGIN_RELEASE_TOKEN` as an org secret
- Pass it through in each plugin's `build.yml` (32 repos call this workflow)
- Prove a real release on `boss-plugin-bookmarks` before enabling the ruleset there